### PR TITLE
auto_generate_release_plugins

### DIFF
--- a/OSGi/com.dotcms.3rd.party/build.gradle
+++ b/OSGi/com.dotcms.3rd.party/build.gradle
@@ -11,7 +11,7 @@ repositories {
 
 dependencies {
     compile fileTree(dir: 'src/main/resources/libs', include: '*.jar')
-    compile('com.dotcms:dotcms:5.3.9') { transitive = true }
+    compile('com.dotcms:dotcms:20.10.1') { transitive = true }
 }
 
 import java.util.jar.*

--- a/OSGi/com.dotcms.actionlet/build.gradle
+++ b/OSGi/com.dotcms.actionlet/build.gradle
@@ -10,7 +10,7 @@ repositories {
 }
 
 dependencies {
-    compile('com.dotcms:dotcms:5.3.9') { transitive = true }
+    compile('com.dotcms:dotcms:20.10.1') { transitive = true }
 }
 
 import java.util.jar.*

--- a/OSGi/com.dotcms.aop/build.gradle
+++ b/OSGi/com.dotcms.aop/build.gradle
@@ -74,10 +74,10 @@ dependencies {
 
     ajc     "org.aspectj:aspectjtools:1.8.10"
     providedCompile "org.aspectj:aspectjrt:1.8.10"
-    providedCompile (group: 'com.dotcms', name: 'dotcms', version: '5.3.9'){
+    providedCompile (group: 'com.dotcms', name: 'dotcms', version: '20.10.1'){
         transitive = true
     }
-    aspects (group: 'com.dotcms', name: 'dotcms', version: '5.3.9')
+    aspects (group: 'com.dotcms', name: 'dotcms', version: '20.10.1')
 
     providedCompile "javax.servlet:javax.servlet-api:3.1.0"
 }

--- a/OSGi/com.dotcms.app.example/build.gradle
+++ b/OSGi/com.dotcms.app.example/build.gradle
@@ -10,7 +10,7 @@ repositories {
 }
 
 dependencies {
-    compile('com.dotcms:dotcms:5.3.9') { transitive = true }
+    compile('com.dotcms:dotcms:20.10.1') { transitive = true }
     
     testCompile group: 'junit', name: 'junit-dep', version: '4.10'
 }

--- a/OSGi/com.dotcms.custom.spring/build.gradle
+++ b/OSGi/com.dotcms.custom.spring/build.gradle
@@ -14,7 +14,7 @@ configurations {
 }
 
 dependencies {
-    compile('com.dotcms:dotcms:5.3.9') { transitive = true }
+    compile('com.dotcms:dotcms:20.10.1') { transitive = true }
     //Resolve dependencies. These jars can be downloaded from our Maven Repo
     //In case you want to create a Controller using other Spring version,
     //just change the version Attribute.

--- a/OSGi/com.dotcms.dynamic.skeleton/build.gradle
+++ b/OSGi/com.dotcms.dynamic.skeleton/build.gradle
@@ -23,7 +23,7 @@ dependencies {
     // include all jars within the resource libs
     compile fileTree(dir: 'src/main/resources/libs', include: '*.jar')
     // Using all jar from artifactory part of the dotcms group
-    compile('com.dotcms:dotcms:5.3.9') { transitive = true }
+    compile('com.dotcms:dotcms:20.10.1') { transitive = true }
 }
 
 import java.util.jar.*

--- a/OSGi/com.dotcms.fixasset/build.gradle
+++ b/OSGi/com.dotcms.fixasset/build.gradle
@@ -10,7 +10,7 @@ repositories {
 }
 
 dependencies {
-    compile('com.dotcms:dotcms:5.3.9') { transitive = true }
+    compile('com.dotcms:dotcms:20.10.1') { transitive = true }
 }
 
 import java.util.jar.*

--- a/OSGi/com.dotcms.hooks.validations/build.gradle
+++ b/OSGi/com.dotcms.hooks.validations/build.gradle
@@ -10,7 +10,7 @@ repositories {
 }
 
 dependencies {
-    compile('com.dotcms:dotcms:5.3.7') { transitive = true }
+    compile('com.dotcms:dotcms:5.3.9') { transitive = true }
 }
 
 import java.util.jar.*

--- a/OSGi/com.dotcms.hooks/build.gradle
+++ b/OSGi/com.dotcms.hooks/build.gradle
@@ -10,7 +10,7 @@ repositories {
 }
 
 dependencies {
-    compile('com.dotcms:dotcms:5.3.9') { transitive = true }
+    compile('com.dotcms:dotcms:20.10.1') { transitive = true }
 }
 
 import java.util.jar.*

--- a/OSGi/com.dotcms.job/build.gradle
+++ b/OSGi/com.dotcms.job/build.gradle
@@ -10,7 +10,7 @@ repositories {
 }
 
 dependencies {
-    compile('com.dotcms:dotcms:5.3.9') { transitive = true }
+    compile('com.dotcms:dotcms:20.10.1') { transitive = true }
 }
 
 import java.util.jar.*

--- a/OSGi/com.dotcms.override/build.gradle
+++ b/OSGi/com.dotcms.override/build.gradle
@@ -10,7 +10,7 @@ repositories {
 }
 
 dependencies {
-    compile('com.dotcms:dotcms:5.3.9') { transitive = true }
+    compile('com.dotcms:dotcms:20.10.1') { transitive = true }
 }
 
 import java.util.jar.*

--- a/OSGi/com.dotcms.portlet/build.gradle
+++ b/OSGi/com.dotcms.portlet/build.gradle
@@ -10,7 +10,7 @@ repositories {
 }
 
 dependencies {
-    compile('com.dotcms:dotcms:5.3.9') { transitive = true }
+    compile('com.dotcms:dotcms:20.10.1') { transitive = true }
 }
 
 import java.util.jar.*

--- a/OSGi/com.dotcms.pushpublish.listener/build.gradle
+++ b/OSGi/com.dotcms.pushpublish.listener/build.gradle
@@ -10,7 +10,7 @@ repositories {
 }
 
 dependencies {
-    compile('com.dotcms:dotcms:5.3.9') { transitive = true }
+    compile('com.dotcms:dotcms:20.10.1') { transitive = true }
 }
 
 import java.util.jar.*

--- a/OSGi/com.dotcms.rest/build.gradle
+++ b/OSGi/com.dotcms.rest/build.gradle
@@ -10,7 +10,7 @@ repositories {
 }
 
 dependencies {
-    compile('com.dotcms:dotcms:5.3.9') { transitive = true }
+    compile('com.dotcms:dotcms:20.10.1') { transitive = true }
 }
 
 import java.util.jar.*

--- a/OSGi/com.dotcms.ruleengine.velocityscriptingactionlet/build.gradle
+++ b/OSGi/com.dotcms.ruleengine.velocityscriptingactionlet/build.gradle
@@ -15,7 +15,7 @@ configurations {
 }
 
 dependencies {
-    compile('com.dotcms:dotcms:5.3.9') { transitive = true }
+    compile('com.dotcms:dotcms:20.10.1') { transitive = true }
 
     testCompile 'org.mockito:mockito-core:2.0.31-beta'
     testCompile 'org.hamcrest:hamcrest-all:1.3'

--- a/OSGi/com.dotcms.ruleengine.visitoripconditionlet/build.gradle
+++ b/OSGi/com.dotcms.ruleengine.visitoripconditionlet/build.gradle
@@ -15,7 +15,7 @@ configurations {
 }
 
 dependencies {
-    compile('com.dotcms:dotcms:5.3.9') { transitive = true }
+    compile('com.dotcms:dotcms:20.10.1') { transitive = true }
 
     testCompile 'org.mockito:mockito-core:2.0.31-beta'
     testCompile 'org.hamcrest:hamcrest-all:1.3'

--- a/OSGi/com.dotcms.simpleService/build.gradle
+++ b/OSGi/com.dotcms.simpleService/build.gradle
@@ -10,7 +10,7 @@ repositories {
 }
 
 dependencies {
-    compile('com.dotcms:dotcms:5.3.9') { transitive = true }
+    compile('com.dotcms:dotcms:20.10.1') { transitive = true }
 }
 
 import java.util.jar.*

--- a/OSGi/com.dotcms.spring/build.gradle
+++ b/OSGi/com.dotcms.spring/build.gradle
@@ -10,7 +10,7 @@ repositories {
 }
 
 dependencies {
-    compile('com.dotcms:dotcms:5.3.9') { transitive = true }
+    compile('com.dotcms:dotcms:20.10.1') { transitive = true }
 }
 
 import java.util.jar.*

--- a/OSGi/com.dotcms.staticpublish.listener/build.gradle
+++ b/OSGi/com.dotcms.staticpublish.listener/build.gradle
@@ -14,7 +14,7 @@ configurations {
 }
 
 dependencies {
-    compile('com.dotcms:dotcms:5.3.9') { transitive = true }
+    compile('com.dotcms:dotcms:20.10.1') { transitive = true }
 
     compileOnly('com.hierynomus:sshj:0.23.0'){
         exclude group: 'org.bouncycastle' //Why we exlude? See README's important notes.

--- a/OSGi/com.dotcms.tuckey/build.gradle
+++ b/OSGi/com.dotcms.tuckey/build.gradle
@@ -10,7 +10,7 @@ repositories {
 }
 
 dependencies {
-    compile('com.dotcms:dotcms:5.3.9') { transitive = true }
+    compile('com.dotcms:dotcms:20.10.1') { transitive = true }
 }
 
 import java.util.jar.*

--- a/OSGi/com.dotcms.viewtool/build.gradle
+++ b/OSGi/com.dotcms.viewtool/build.gradle
@@ -10,7 +10,7 @@ repositories {
 }
 
 dependencies {
-    compile('com.dotcms:dotcms:5.3.9') { transitive = true }
+    compile('com.dotcms:dotcms:20.10.1') { transitive = true }
 }
 
 import java.util.jar.*

--- a/OSGi/com.dotcms.webinterceptor/build.gradle
+++ b/OSGi/com.dotcms.webinterceptor/build.gradle
@@ -10,7 +10,7 @@ repositories {
 }
 
 dependencies {
-    compile('com.dotcms:dotcms:5.3.9') { transitive = true }
+    compile('com.dotcms:dotcms:20.10.1') { transitive = true }
 }
 
 import java.util.jar.*

--- a/static/com.dotcms.hook/build.gradle
+++ b/static/com.dotcms.hook/build.gradle
@@ -16,7 +16,7 @@ repositories {
 // In this section you declare the dependencies for your production and test code
 dependencies {
     compileOnly fileTree(dir: 'lib', include: '*.jar')
-    compileOnly (group: 'com.dotcms', name: 'dotcms', version: '5.3.9'){
+    compileOnly (group: 'com.dotcms', name: 'dotcms', version: '20.10.1'){
         transitive = true
     }
 }

--- a/static/com.dotcms.macro/build.gradle
+++ b/static/com.dotcms.macro/build.gradle
@@ -16,7 +16,7 @@ repositories {
 // In this section you declare the dependencies for your production and test code
 dependencies {
     compileOnly fileTree(dir: 'lib', include: '*.jar')
-    compileOnly (group: 'com.dotcms', name: 'dotcms', version: '5.3.9'){
+    compileOnly (group: 'com.dotcms', name: 'dotcms', version: '20.10.1'){
         transitive = true
     }
 }

--- a/static/com.dotcms.portlet/build.gradle
+++ b/static/com.dotcms.portlet/build.gradle
@@ -16,7 +16,7 @@ repositories {
 // In this section you declare the dependencies for your production and test code
 dependencies {
     compileOnly fileTree(dir: 'lib', include: '*.jar')
-    compileOnly (group: 'com.dotcms', name: 'dotcms', version: '5.3.9'){
+    compileOnly (group: 'com.dotcms', name: 'dotcms', version: '20.10.1'){
         transitive = true
     }
 }

--- a/static/com.dotcms.servlet/build.gradle
+++ b/static/com.dotcms.servlet/build.gradle
@@ -16,7 +16,7 @@ repositories {
 // In this section you declare the dependencies for your production and test code
 dependencies {
     compileOnly fileTree(dir: 'lib', include: '*.jar')
-    compileOnly (group: 'com.dotcms', name: 'dotcms', version: '5.3.9'){
+    compileOnly (group: 'com.dotcms', name: 'dotcms', version: '20.10.1'){
         transitive = true
     }
     compileOnly group: 'javax.servlet', name: 'javax.servlet-api', version: '3.0.1'

--- a/static/com.dotcms.skeleton/build.gradle
+++ b/static/com.dotcms.skeleton/build.gradle
@@ -16,7 +16,7 @@ repositories {
 // In this section you declare the dependencies for your production and test code
 dependencies {
     compileOnly fileTree(dir: 'lib', include: '*.jar')
-    compileOnly (group: 'com.dotcms', name: 'dotcms', version: '5.3.9'){
+    compileOnly (group: 'com.dotcms', name: 'dotcms', version: '20.10.1'){
         transitive = true
     }
 }

--- a/static/com.dotcms.viewtool/build.gradle
+++ b/static/com.dotcms.viewtool/build.gradle
@@ -16,7 +16,7 @@ repositories {
 // In this section you declare the dependencies for your production and test code
 dependencies {
     compileOnly fileTree(dir: 'lib', include: '*.jar')
-    compileOnly (group: 'com.dotcms', name: 'dotcms', version: '5.3.9'){
+    compileOnly (group: 'com.dotcms', name: 'dotcms', version: '20.10.1'){
         transitive = true
     }
 }


### PR DESCRIPTION
This time we include the new app example plugin and exclude the servlet plugin that now is updated to point to webinterceptor